### PR TITLE
Add implementation wrapper for Optimization Profile

### DIFF
--- a/src/builder.rs
+++ b/src/builder.rs
@@ -27,32 +27,14 @@ impl Builder {
 
     /// Create a new optimization profile.
     ///
-    /// Note that the official TensorRT documentation states:
-    ///
-    /// "If the network has any dynamic input tensors, the appropriate calls to setDimensions() must
-    /// be made."
-    ///
-    /// But this part of the API has not been implemented yet in `async-tensorrt`.
-    ///
-    /// This function is still useful to allocate the optimization profile in the [`Builder`], which
-    /// may or may not actually affect the building process later.
-    ///
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a68a8b59fbf86e42762b7087e6ffe6fb4)
     #[inline(always)]
-    pub fn add_optimization_profile(&mut self) -> Result<()> {
-        self.inner.add_optimization_profile()
+    pub fn add_optimization_profile<'a>(&'a mut self) -> Result<OptimizationProfile<'a>> {
+        let profile = self.inner.add_optimization_profile()?;
+        Ok(OptimizationProfile::from_inner(profile))
     }
 
-    /// Create a new optimization profile.
-    ///
-    /// Note that the official TensorRT documentation states:
-    ///
-    /// "If the network has any dynamic input tensors, the appropriate calls to setDimensions() must
-    /// be made."
-    ///
-    /// But this part of the API has not been implemented yet in `async-tensorrt`.
-    ///
-    /// This function is still useful to allocate the optimization profile in the [`Builder`], which
+    /// Create a new optimization profile. This allocates an empty optimization profile, which
     /// may or may not actually affect the building process later.
     ///
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a68a8b59fbf86e42762b7087e6ffe6fb4)
@@ -60,27 +42,6 @@ impl Builder {
     pub fn with_optimization_profile(mut self) -> Result<Self> {
         self.add_optimization_profile()?;
         Ok(self)
-    }
-
-    /// Create a new optimization profile. This function returns a mutable
-    /// reference to to configure the optimization profile.
-    ///
-    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a68a8b59fbf86e42762b7087e6ffe6fb4)
-    #[inline(always)]
-    pub fn optimization_profile_mut<'a>(&'a mut self) -> Result<OptimizationProfile<'a>> {
-        self.add_optimization_profile()?;
-        let profile = self.inner.optimization_profile_mut().unwrap();
-        Ok(OptimizationProfile::from_inner_mut(profile))
-    }
-
-    /// Return a reference to the optimization profile. None if the optimization
-    /// profile hasn't been created yet.
-    ///
-    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a68a8b59fbf86e42762b7087e6ffe6fb4)
-    #[inline(always)]
-    pub fn optimization_profile<'a>(&'a self) -> Option<OptimizationProfile<'a>> {
-        let profile = self.inner.optimization_profile();
-        profile.map(|profile| OptimizationProfile::from_inner(profile))
     }
 
     /// Create a builder configuration object.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -78,9 +78,9 @@ impl Builder {
     ///
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a68a8b59fbf86e42762b7087e6ffe6fb4)
     #[inline(always)]
-    pub fn optimization_profile<'a>(&'a self) -> Result<Option<OptimizationProfile<'a>>> {
+    pub fn optimization_profile<'a>(&'a self) -> Option<OptimizationProfile<'a>> {
         let profile = self.inner.optimization_profile();
-        Ok(profile.map(|profile| OptimizationProfile::from_inner(profile)))
+        profile.map(|profile| OptimizationProfile::from_inner(profile))
     }
 
     /// Create a builder configuration object.

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -29,8 +29,8 @@ impl Builder {
     ///
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a68a8b59fbf86e42762b7087e6ffe6fb4)
     #[inline(always)]
-    pub fn add_optimization_profile<'a>(&'a mut self) -> Result<OptimizationProfile<'a>> {
-        let profile = self.inner.add_optimization_profile()?;
+    pub fn create_optimization_profile<'a>(&'a mut self) -> Result<OptimizationProfile<'a>> {
+        let profile = self.inner.create_optimization_profile()?;
         Ok(OptimizationProfile::from_inner(profile))
     }
 
@@ -39,8 +39,18 @@ impl Builder {
     ///
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a68a8b59fbf86e42762b7087e6ffe6fb4)
     #[inline(always)]
+    pub fn add_optimization_profile(&mut self) -> Result<()> {
+        self.create_optimization_profile()?;
+        Ok(())
+    }
+
+    /// Create a new optimization profile. This allocates an empty optimization profile, which
+    /// may or may not actually affect the building process later.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a68a8b59fbf86e42762b7087e6ffe6fb4)
+    #[inline(always)]
     pub fn with_optimization_profile(mut self) -> Result<Self> {
-        self.add_optimization_profile()?;
+        self.create_optimization_profile()?;
         Ok(self)
     }
 

--- a/src/builder.rs
+++ b/src/builder.rs
@@ -5,6 +5,8 @@ use crate::ffi::memory::HostBuffer;
 use crate::ffi::network::{NetworkDefinition, NetworkDefinitionCreationFlags};
 use crate::ffi::sync::builder::Builder as InnerBuilder;
 
+use super::optimization_profile::OptimizationProfile;
+
 type Result<T> = std::result::Result<T, crate::error::Error>;
 
 /// Builds an engine from a network definition.
@@ -58,6 +60,27 @@ impl Builder {
     pub fn with_optimization_profile(mut self) -> Result<Self> {
         self.add_optimization_profile()?;
         Ok(self)
+    }
+
+    /// Create a new optimization profile. This function returns a mutable
+    /// reference to to configure the optimization profile.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a68a8b59fbf86e42762b7087e6ffe6fb4)
+    #[inline(always)]
+    pub fn optimization_profile_mut<'a>(&'a mut self) -> Result<OptimizationProfile<'a>> {
+        self.add_optimization_profile()?;
+        let profile = self.inner.optimization_profile_mut().unwrap();
+        Ok(OptimizationProfile::from_inner_mut(profile))
+    }
+
+    /// Return a reference to the optimization profile. None if the optimization
+    /// profile hasn't been created yet.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_builder.html#a68a8b59fbf86e42762b7087e6ffe6fb4)
+    #[inline(always)]
+    pub fn optimization_profile<'a>(&'a self) -> Result<Option<OptimizationProfile<'a>>> {
+        let profile = self.inner.optimization_profile();
+        Ok(profile.map(|profile| OptimizationProfile::from_inner(profile)))
     }
 
     /// Create a builder configuration object.

--- a/src/ffi/mod.rs
+++ b/src/ffi/mod.rs
@@ -15,6 +15,9 @@ pub mod network;
 pub mod parser;
 pub mod sync;
 
+// Defined in NvInferRuntimeBase.h
+const MAX_DIMS: usize = 8;
+
 /// Convenience macro for turning TensorRT error code into a `std::result::Result`.
 ///
 /// # Usage

--- a/src/ffi/sync/builder.rs
+++ b/src/ffi/sync/builder.rs
@@ -51,7 +51,7 @@ impl Builder {
             return ((IBuilder*) internal)->createOptimizationProfile();
         });
         let profile = result!(optimization_profile_internal, optimization_profile_internal)?;
-        Ok(OptimizationProfile::wrap(profile))
+        Ok(OptimizationProfile::wrap(profile, self))
     }
 
     pub fn add_optimization_profile(&mut self) -> Result<()> {

--- a/src/ffi/sync/builder.rs
+++ b/src/ffi/sync/builder.rs
@@ -43,7 +43,7 @@ impl Builder {
         result!(addr, Builder { addr, device })
     }
 
-    pub fn add_optimization_profile(&mut self) -> Result<OptimizationProfile> {
+    pub fn create_optimization_profile(&mut self) -> Result<OptimizationProfile> {
         let internal = self.as_mut_ptr();
         let optimization_profile_internal = cpp!(unsafe [
             internal as "void*"
@@ -54,8 +54,13 @@ impl Builder {
         Ok(OptimizationProfile::wrap(profile))
     }
 
+    pub fn add_optimization_profile(&mut self) -> Result<()> {
+        self.create_optimization_profile()?;
+        Ok(())
+    }
+
     pub fn with_optimization_profile(mut self) -> Result<Self> {
-        self.add_optimization_profile()?;
+        self.create_optimization_profile()?;
         Ok(self)
     }
 

--- a/src/ffi/sync/mod.rs
+++ b/src/ffi/sync/mod.rs
@@ -1,3 +1,4 @@
 pub mod builder;
 pub mod engine;
+pub mod optimization_profile;
 pub mod runtime;

--- a/src/ffi/sync/optimization_profile.rs
+++ b/src/ffi/sync/optimization_profile.rs
@@ -1,0 +1,241 @@
+use cpp::cpp;
+
+use crate::ffi::result;
+
+type Result<T> = std::result::Result<T, crate::error::Error>;
+
+/// Synchronous implementation of [`crate::OptimizationProfile`].
+///
+/// Refer to [`crate::OptimizationProfile`] for documentation.
+pub struct OptimizationProfile(*mut std::ffi::c_void);
+
+/// Implements [`Send`] for [`OptimizationProfile`].
+///
+/// # Safety
+///
+/// The TensorRT API is thread-safe with regards to all operations on [`OptimizationProfile`].
+unsafe impl Send for OptimizationProfile {}
+
+/// Implements [`Sync`] for [`OptimizationProfile`].
+///
+/// # Safety
+///
+/// The TensorRT API is thread-safe with regards to all operations on [`OptimizationProfile`].
+unsafe impl Sync for OptimizationProfile {}
+
+#[derive(Copy, Clone, Debug)]
+#[repr(i32)]
+enum OptimizationProfileSelector {
+    Min = 0,
+    Opt = 1,
+    Max = 2,
+}
+
+// Defined in NvInferRuntimeBase.h
+const MAX_DIMS: usize = 8;
+
+impl OptimizationProfile {
+    #[inline]
+    pub(crate) fn wrap(internal: *mut std::ffi::c_void) -> Self {
+        OptimizationProfile(internal)
+    }
+
+    pub fn set_min_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
+        return self.set_shape_values(input_name, OptimizationProfileSelector::Min as i32, values);
+    }
+
+    pub fn set_opt_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
+        return self.set_shape_values(input_name, OptimizationProfileSelector::Opt as i32, values);
+    }
+
+    pub fn set_max_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
+        return self.set_shape_values(input_name, OptimizationProfileSelector::Max as i32, values);
+    }
+
+    fn set_shape_values(&mut self, input_name: &str, select: i32, values: &[i32]) -> bool {
+        let internal = self.as_mut_ptr();
+        let input_name_cstr = std::ffi::CString::new(input_name).unwrap();
+        let input_name_ptr = input_name_cstr.as_ptr();
+        let nb_values = values.len() as i32;
+        let values_ptr = values.as_ptr();
+
+        let res = cpp!(unsafe [
+            internal as "void*",
+            input_name_ptr as "const char*",
+            select as "OptProfileSelector",
+            values_ptr as "const int32_t*",
+            nb_values as "int32_t"
+        ] -> bool as "bool" {
+            return ((IOptimizationProfile*) internal)->setShapeValues(input_name_ptr, select, values_ptr, nb_values);
+        });
+        res
+    }
+
+    pub fn get_min_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
+        return self.get_shape_values(input_name, OptimizationProfileSelector::Min as i32);
+    }
+
+    pub fn get_opt_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
+        return self.get_shape_values(input_name, OptimizationProfileSelector::Opt as i32);
+    }
+
+    pub fn get_max_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
+        return self.get_shape_values(input_name, OptimizationProfileSelector::Max as i32);
+    }
+
+    fn get_shape_values(&self, input_name: &str, select: i32) -> Result<Option<Vec<i32>>> {
+        let internal = self.as_ptr();
+        let input_name_cstr = std::ffi::CString::new(input_name).unwrap();
+        let input_name_ptr = input_name_cstr.as_ptr();
+
+        let nb_shape_values = cpp!(unsafe [
+            internal as "void*",
+            input_name_ptr as "const char*"
+        ] -> i32 as "int32_t" {
+            return ((const IOptimizationProfile*) internal)->getNbShapeValues(input_name_ptr);
+        });
+
+        if nb_shape_values < 0 {
+            return Ok(None);
+        }
+        let nb_shape_values = nb_shape_values as usize;
+        let mut values = Vec::with_capacity(nb_shape_values);
+
+        let shape_values = cpp!(unsafe [
+            internal as "void*",
+            input_name_ptr as "const char*",
+            select as "OptProfileSelector"
+        ] -> *const i32 as "const int32_t*" {
+            return ((const IOptimizationProfile*) internal)->getShapeValues(input_name_ptr, select);
+        });
+        let shape_values = result!(shape_values, shape_values)?;
+        for i in 0..nb_shape_values {
+            let dim = unsafe { *shape_values.add(i) };
+            values.push(dim)
+        }
+        return Ok(Some(values));
+    }
+
+    pub fn set_min_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
+        return self.set_dimensions(input_name, OptimizationProfileSelector::Min as i32, dims);
+    }
+
+    pub fn set_opt_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
+        return self.set_dimensions(input_name, OptimizationProfileSelector::Opt as i32, dims);
+    }
+
+    pub fn set_max_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
+        return self.set_dimensions(input_name, OptimizationProfileSelector::Max as i32, dims);
+    }
+
+    fn set_dimensions(&mut self, input_name: &str, select: i32, dims: &[i32]) -> bool {
+        let internal = self.as_mut_ptr();
+        let input_name_cstr = std::ffi::CString::new(input_name).unwrap();
+        let input_name_ptr = input_name_cstr.as_ptr();
+        let nb_dims = dims.len() as i32;
+        let dims_ptr = dims.as_ptr();
+
+        let res = cpp!(unsafe [
+            internal as "void*",
+            input_name_ptr as "const char*",
+            select as "OptProfileSelector",
+            dims_ptr as "const int32_t*",
+            nb_dims as "int32_t"
+        ] -> bool as "bool" {
+            nvinfer1::Dims xdims;
+            xdims.nbDims = nb_dims;
+            for (int i = 0; i < xdims.nbDims; ++i) {
+                xdims.d[i] = dims_ptr[i];
+            }
+
+            return ((IOptimizationProfile*) internal)->setDimensions(input_name_ptr, select, xdims);
+        });
+        res
+    }
+
+    pub fn get_min_dimensions(&self, input_name: &str) -> Option<Vec<i32>> {
+        return self.get_dimensions(input_name, OptimizationProfileSelector::Min as i32);
+    }
+
+    pub fn get_opt_dimensions(&self, input_name: &str) -> Option<Vec<i32>> {
+        return self.get_dimensions(input_name, OptimizationProfileSelector::Opt as i32);
+    }
+
+    pub fn get_max_dimensions(&self, input_name: &str) -> Option<Vec<i32>> {
+        return self.get_dimensions(input_name, OptimizationProfileSelector::Max as i32);
+    }
+
+    fn get_dimensions(&self, input_name: &str, select: i32) -> Option<Vec<i32>> {
+        let internal = self.as_ptr();
+        let input_name_cstr = std::ffi::CString::new(input_name).unwrap();
+        let input_name_ptr = input_name_cstr.as_ptr();
+        let mut dims = Vec::with_capacity(MAX_DIMS);
+        let dims_ptr = dims.as_mut_ptr();
+
+        let num_dimensions = cpp!(unsafe [
+            internal as "void*",
+            input_name_ptr as "const char*",
+            select as "OptProfileSelector",
+            dims_ptr as "int32_t*"
+        ] -> i32 as "int32_t" {
+            auto dims = ((const IOptimizationProfile*) internal)->getDimensions(input_name_ptr, select);
+            if (dims.nbDims > 0) {
+                for (int i = 0; i < dims.nbDims; ++i) {
+                    dims_ptr[i] = dims.d[i];
+                }
+            }
+            return dims.nbDims;
+        });
+        if num_dimensions >= 0 {
+            // Safety: The vec has been initialized up until num_dimensions elements
+            unsafe {
+                dims.set_len(num_dimensions as usize);
+            }
+            return Some(dims);
+        } else {
+            return None;
+        }
+    }
+
+    pub fn set_extra_memory_target(&mut self, target: f32) -> bool {
+        let internal = self.as_ptr();
+        cpp!(unsafe [
+            internal as "const void*",
+            target as "float"
+        ] -> bool as "bool" {
+            return ((IOptimizationProfile*) internal)->setExtraMemoryTarget(target);
+        })
+    }
+
+    pub fn get_extra_memory_target(&self) -> f32 {
+        let internal = self.as_ptr();
+        cpp!(unsafe [
+            internal as "const void*"
+        ] -> f32 as "float" {
+            return ((const IOptimizationProfile*) internal)->getExtraMemoryTarget();
+        })
+    }
+
+    pub fn is_valid(&self) -> bool {
+        let internal = self.as_ptr();
+        cpp!(unsafe [
+            internal as "const void*"
+        ] -> bool as "bool" {
+            return ((const IOptimizationProfile*) internal)->isValid();
+        })
+    }
+
+    /// Get internal readonly pointer.
+    #[inline(always)]
+    pub fn as_ptr(&self) -> *const std::ffi::c_void {
+        let OptimizationProfile(internal) = *self;
+        internal
+    }
+
+    /// Get internal mutable pointer.
+    #[inline(always)]
+    pub fn as_mut_ptr(&mut self) -> *mut std::ffi::c_void {
+        let OptimizationProfile(internal) = *self;
+        internal
+    }
+}

--- a/src/ffi/sync/optimization_profile.rs
+++ b/src/ffi/sync/optimization_profile.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use cpp::cpp;
 
 use crate::ffi::result;
@@ -8,21 +10,21 @@ type Result<T> = std::result::Result<T, crate::error::Error>;
 /// Synchronous implementation of [`crate::OptimizationProfile`].
 ///
 /// Refer to [`crate::OptimizationProfile`] for documentation.
-pub struct OptimizationProfile(*mut std::ffi::c_void);
+pub struct OptimizationProfile<'a>(*mut std::ffi::c_void, PhantomData<&'a ()>);
 
 /// Implements [`Send`] for [`OptimizationProfile`].
 ///
 /// # Safety
 ///
 /// The TensorRT API is thread-safe with regards to all operations on [`OptimizationProfile`].
-unsafe impl Send for OptimizationProfile {}
+unsafe impl<'a> Send for OptimizationProfile<'a> {}
 
 /// Implements [`Sync`] for [`OptimizationProfile`].
 ///
 /// # Safety
 ///
 /// The TensorRT API is thread-safe with regards to all operations on [`OptimizationProfile`].
-unsafe impl Sync for OptimizationProfile {}
+unsafe impl<'a> Sync for OptimizationProfile<'a> {}
 
 #[derive(Copy, Clone, Debug)]
 #[repr(i32)]
@@ -32,10 +34,10 @@ enum OptimizationProfileSelector {
     Max = 2,
 }
 
-impl OptimizationProfile {
+impl<'a> OptimizationProfile<'a> {
     #[inline]
-    pub(crate) fn wrap(internal: *mut std::ffi::c_void) -> Self {
-        OptimizationProfile(internal)
+    pub(crate) fn wrap<T>(internal: *mut std::ffi::c_void, _builder: &'a T) -> Self {
+        OptimizationProfile(internal, PhantomData)
     }
 
     pub fn set_min_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
@@ -226,14 +228,14 @@ impl OptimizationProfile {
     /// Get internal readonly pointer.
     #[inline(always)]
     pub fn as_ptr(&self) -> *const std::ffi::c_void {
-        let OptimizationProfile(internal) = *self;
+        let OptimizationProfile(internal, _) = *self;
         internal
     }
 
     /// Get internal mutable pointer.
     #[inline(always)]
     pub fn as_mut_ptr(&mut self) -> *mut std::ffi::c_void {
-        let OptimizationProfile(internal) = *self;
+        let OptimizationProfile(internal, _) = *self;
         internal
     }
 }

--- a/src/ffi/sync/optimization_profile.rs
+++ b/src/ffi/sync/optimization_profile.rs
@@ -1,6 +1,7 @@
 use cpp::cpp;
 
 use crate::ffi::result;
+use crate::ffi::MAX_DIMS;
 
 type Result<T> = std::result::Result<T, crate::error::Error>;
 
@@ -30,9 +31,6 @@ enum OptimizationProfileSelector {
     Opt = 1,
     Max = 2,
 }
-
-// Defined in NvInferRuntimeBase.h
-const MAX_DIMS: usize = 8;
 
 impl OptimizationProfile {
     #[inline]

--- a/src/lib.rs
+++ b/src/lib.rs
@@ -4,6 +4,7 @@ pub mod builder;
 pub mod engine;
 pub mod error;
 pub mod ffi;
+pub mod optimization_profile;
 pub mod runtime;
 
 #[cfg(test)]
@@ -16,4 +17,5 @@ pub use ffi::builder_config::BuilderConfig;
 pub use ffi::memory::HostBuffer;
 pub use ffi::network::{NetworkDefinition, NetworkDefinitionCreationFlags, Tensor};
 pub use ffi::parser::Parser;
+pub use optimization_profile::OptimizationProfile;
 pub use runtime::Runtime;

--- a/src/optimization_profile.rs
+++ b/src/optimization_profile.rs
@@ -1,3 +1,5 @@
+use std::marker::PhantomData;
+
 use crate::ffi::sync::optimization_profile::OptimizationProfile as InnerOptimizationProfile;
 
 type Result<T> = std::result::Result<T, crate::error::Error>;
@@ -6,24 +8,16 @@ type Result<T> = std::result::Result<T, crate::error::Error>;
 ///
 /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html)
 pub struct OptimizationProfile<'a> {
-    inner: Option<&'a InnerOptimizationProfile>,
-    inner_mut: Option<&'a mut InnerOptimizationProfile>,
+    inner: InnerOptimizationProfile,
+    phantom: PhantomData<&'a ()>,
 }
 
 impl<'a> OptimizationProfile<'a> {
     /// Create [`OptimizationProfile`] from its inner object.
-    pub fn from_inner(inner: &'a InnerOptimizationProfile) -> OptimizationProfile<'a> {
+    pub fn from_inner(inner: InnerOptimizationProfile) -> OptimizationProfile<'a> {
         Self {
-            inner: Some(inner),
-            inner_mut: None,
-        }
-    }
-
-    /// Create [`OptimizationProfile`] from its inner mutable object.
-    pub fn from_inner_mut(inner: &'a mut InnerOptimizationProfile) -> OptimizationProfile<'a> {
-        Self {
-            inner: None,
-            inner_mut: Some(inner),
+            inner,
+            phantom: PhantomData,
         }
     }
 
@@ -32,7 +26,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ab723695382d6b03d4a0463b8cbe2b19f)
     #[inline(always)]
     pub fn set_min_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
-        return self.inner_mut().set_min_dimensions(input_name, dims);
+        return self.inner.set_min_dimensions(input_name, dims);
     }
 
     /// Set the optimum dimensions for a dynamic input tensor.
@@ -40,7 +34,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ab723695382d6b03d4a0463b8cbe2b19f)
     #[inline(always)]
     pub fn set_opt_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
-        return self.inner_mut().set_opt_dimensions(input_name, dims);
+        return self.inner.set_opt_dimensions(input_name, dims);
     }
 
     /// Set the maximum dimensions for a dynamic input tensor.
@@ -48,7 +42,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ab723695382d6b03d4a0463b8cbe2b19f)
     #[inline(always)]
     pub fn set_max_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
-        return self.inner_mut().set_max_dimensions(input_name, dims);
+        return self.inner.set_max_dimensions(input_name, dims);
     }
 
     /// Get the minimum dimensions for a dynamic input tensor.
@@ -56,7 +50,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a495725c79864f3e4059055307a8cc59d)
     #[inline(always)]
     pub fn get_min_dimensions(&'a self, input_name: &str) -> Option<Vec<i32>> {
-        return self.inner().get_min_dimensions(input_name);
+        return self.inner.get_min_dimensions(input_name);
     }
 
     /// Get the optimum dimensions for a dynamic input tensor.
@@ -64,7 +58,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a495725c79864f3e4059055307a8cc59d)
     #[inline(always)]
     pub fn get_opt_dimensions(&'a self, input_name: &str) -> Option<Vec<i32>> {
-        return self.inner().get_opt_dimensions(input_name);
+        return self.inner.get_opt_dimensions(input_name);
     }
 
     /// Get the maximum dimensions for a dynamic input tensor.
@@ -72,7 +66,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a495725c79864f3e4059055307a8cc59d)
     #[inline(always)]
     pub fn get_max_dimensions(&'a self, input_name: &str) -> Option<Vec<i32>> {
-        return self.inner().get_max_dimensions(input_name);
+        return self.inner.get_max_dimensions(input_name);
     }
 
     /// Set the minimum values for an input shape tensor.
@@ -80,7 +74,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ad89508bb5e59d46d106cb74d70193485)
     #[inline(always)]
     pub fn set_min_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
-        return self.inner_mut().set_min_shape_values(input_name, values);
+        return self.inner.set_min_shape_values(input_name, values);
     }
 
     /// Set the optimum values for an input shape tensor.
@@ -88,7 +82,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ad89508bb5e59d46d106cb74d70193485)
     #[inline(always)]
     pub fn set_opt_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
-        return self.inner_mut().set_opt_shape_values(input_name, values);
+        return self.inner.set_opt_shape_values(input_name, values);
     }
 
     /// Set the maximum values for an input shape tensor.
@@ -96,7 +90,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ad89508bb5e59d46d106cb74d70193485)
     #[inline(always)]
     pub fn set_max_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
-        return self.inner_mut().set_max_shape_values(input_name, values);
+        return self.inner.set_max_shape_values(input_name, values);
     }
 
     /// Get the minimum values for an input shape tensor.
@@ -104,7 +98,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a0654f6beafd1e4004950d5cd45ecab2b)
     #[inline(always)]
     pub fn get_min_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
-        return self.inner().get_min_shape_values(input_name);
+        return self.inner.get_min_shape_values(input_name);
     }
 
     /// Get the optimum values for an input shape tensor.
@@ -112,7 +106,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a0654f6beafd1e4004950d5cd45ecab2b)
     #[inline(always)]
     pub fn get_opt_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
-        return self.inner().get_opt_shape_values(input_name);
+        return self.inner.get_opt_shape_values(input_name);
     }
 
     /// Get the maximum values for an input shape tensor.
@@ -120,7 +114,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a0654f6beafd1e4004950d5cd45ecab2b)
     #[inline(always)]
     pub fn get_max_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
-        return self.inner().get_max_shape_values(input_name);
+        return self.inner.get_max_shape_values(input_name);
     }
 
     /// Set a target for extra GPU memory that may be used by this profile.
@@ -128,7 +122,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ae817a3cfb3f528a7b00173336521a187)
     #[inline(always)]
     pub fn set_extra_memory_target(&mut self, target: f32) -> bool {
-        self.inner_mut().set_extra_memory_target(target)
+        self.inner.set_extra_memory_target(target)
     }
 
     /// Get the extra memory target that has been defined for this profile.
@@ -136,7 +130,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#aa5339baa4f134993667bc2df94cb0c2e)
     #[inline(always)]
     pub fn get_extra_memory_target(&self) -> f32 {
-        self.inner().get_extra_memory_target()
+        self.inner.get_extra_memory_target()
     }
 
     /// Check whether the optimization profile can be passed to an IBuilderConfig object.
@@ -144,18 +138,10 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ae817a3cfb3f528a7b00173336521a187)
     #[inline(always)]
     pub fn is_valid(&self) -> bool {
-        self.inner().is_valid()
+        self.inner.is_valid()
     }
 
     pub fn inner(&self) -> &InnerOptimizationProfile {
-        self.inner_mut
-            .as_ref()
-            .map(|o| &**o)
-            .or(self.inner)
-            .unwrap()
-    }
-
-    fn inner_mut(&mut self) -> &mut InnerOptimizationProfile {
-        *(self.inner_mut.as_mut().unwrap())
+        &self.inner
     }
 }

--- a/src/optimization_profile.rs
+++ b/src/optimization_profile.rs
@@ -147,7 +147,7 @@ impl<'a> OptimizationProfile<'a> {
         self.inner().is_valid()
     }
 
-    fn inner(&self) -> &InnerOptimizationProfile {
+    pub fn inner(&self) -> &InnerOptimizationProfile {
         self.inner_mut
             .as_ref()
             .map(|o| &**o)

--- a/src/optimization_profile.rs
+++ b/src/optimization_profile.rs
@@ -1,0 +1,161 @@
+use crate::ffi::sync::optimization_profile::OptimizationProfile as InnerOptimizationProfile;
+
+type Result<T> = std::result::Result<T, crate::error::Error>;
+
+/// Optimization profile for dynamic input dimensions and shape tensors.
+///
+/// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html)
+pub struct OptimizationProfile<'a> {
+    inner: Option<&'a InnerOptimizationProfile>,
+    inner_mut: Option<&'a mut InnerOptimizationProfile>,
+}
+
+impl<'a> OptimizationProfile<'a> {
+    /// Create [`OptimizationProfile`] from its inner object.
+    pub fn from_inner(inner: &'a InnerOptimizationProfile) -> OptimizationProfile<'a> {
+        Self {
+            inner: Some(inner),
+            inner_mut: None,
+        }
+    }
+
+    /// Create [`OptimizationProfile`] from its inner mutable object.
+    pub fn from_inner_mut(inner: &'a mut InnerOptimizationProfile) -> OptimizationProfile<'a> {
+        Self {
+            inner: None,
+            inner_mut: Some(inner),
+        }
+    }
+
+    /// Set the minimum dimensions for a dynamic input tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ab723695382d6b03d4a0463b8cbe2b19f)
+    #[inline(always)]
+    pub fn set_min_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
+        return self.inner_mut().set_min_dimensions(input_name, dims);
+    }
+
+    /// Set the optimum dimensions for a dynamic input tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ab723695382d6b03d4a0463b8cbe2b19f)
+    #[inline(always)]
+    pub fn set_opt_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
+        return self.inner_mut().set_opt_dimensions(input_name, dims);
+    }
+
+    /// Set the maximum dimensions for a dynamic input tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ab723695382d6b03d4a0463b8cbe2b19f)
+    #[inline(always)]
+    pub fn set_max_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
+        return self.inner_mut().set_max_dimensions(input_name, dims);
+    }
+
+    /// Get the minimum dimensions for a dynamic input tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a495725c79864f3e4059055307a8cc59d)
+    #[inline(always)]
+    pub fn get_min_dimensions(&'a self, input_name: &str) -> Option<Vec<i32>> {
+        return self.inner().get_min_dimensions(input_name);
+    }
+
+    /// Get the optimum dimensions for a dynamic input tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a495725c79864f3e4059055307a8cc59d)
+    #[inline(always)]
+    pub fn get_opt_dimensions(&'a self, input_name: &str) -> Option<Vec<i32>> {
+        return self.inner().get_opt_dimensions(input_name);
+    }
+
+    /// Get the maximum dimensions for a dynamic input tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a495725c79864f3e4059055307a8cc59d)
+    #[inline(always)]
+    pub fn get_max_dimensions(&'a self, input_name: &str) -> Option<Vec<i32>> {
+        return self.inner().get_max_dimensions(input_name);
+    }
+
+    /// Set the minimum values for an input shape tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ad89508bb5e59d46d106cb74d70193485)
+    #[inline(always)]
+    pub fn set_min_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
+        return self.inner_mut().set_min_shape_values(input_name, values);
+    }
+
+    /// Set the optimum values for an input shape tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ad89508bb5e59d46d106cb74d70193485)
+    #[inline(always)]
+    pub fn set_opt_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
+        return self.inner_mut().set_opt_shape_values(input_name, values);
+    }
+
+    /// Set the maximum values for an input shape tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ad89508bb5e59d46d106cb74d70193485)
+    #[inline(always)]
+    pub fn set_max_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
+        return self.inner_mut().set_max_shape_values(input_name, values);
+    }
+
+    /// Get the minimum values for an input shape tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a0654f6beafd1e4004950d5cd45ecab2b)
+    #[inline(always)]
+    pub fn get_min_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
+        return self.inner().get_min_shape_values(input_name);
+    }
+
+    /// Get the optimum values for an input shape tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a0654f6beafd1e4004950d5cd45ecab2b)
+    #[inline(always)]
+    pub fn get_opt_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
+        return self.inner().get_opt_shape_values(input_name);
+    }
+
+    /// Get the maximum values for an input shape tensor.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a0654f6beafd1e4004950d5cd45ecab2b)
+    #[inline(always)]
+    pub fn get_max_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
+        return self.inner().get_max_shape_values(input_name);
+    }
+
+    /// Set a target for extra GPU memory that may be used by this profile.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ae817a3cfb3f528a7b00173336521a187)
+    #[inline(always)]
+    pub fn set_extra_memory_target(&mut self, target: f32) -> bool {
+        self.inner_mut().set_extra_memory_target(target)
+    }
+
+    /// Get the extra memory target that has been defined for this profile.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#aa5339baa4f134993667bc2df94cb0c2e)
+    #[inline(always)]
+    pub fn get_extra_memory_target(&self) -> f32 {
+        self.inner().get_extra_memory_target()
+    }
+
+    /// Check whether the optimization profile can be passed to an IBuilderConfig object.
+    ///
+    /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ae817a3cfb3f528a7b00173336521a187)
+    #[inline(always)]
+    pub fn is_valid(&self) -> bool {
+        self.inner().is_valid()
+    }
+
+    fn inner(&self) -> &InnerOptimizationProfile {
+        self.inner_mut
+            .as_ref()
+            .map(|o| &**o)
+            .or(self.inner)
+            .unwrap()
+    }
+
+    fn inner_mut(&mut self) -> &mut InnerOptimizationProfile {
+        *(self.inner_mut.as_mut().unwrap())
+    }
+}

--- a/src/optimization_profile.rs
+++ b/src/optimization_profile.rs
@@ -1,5 +1,3 @@
-use std::marker::PhantomData;
-
 use crate::ffi::sync::optimization_profile::OptimizationProfile as InnerOptimizationProfile;
 
 type Result<T> = std::result::Result<T, crate::error::Error>;
@@ -7,18 +5,12 @@ type Result<T> = std::result::Result<T, crate::error::Error>;
 /// Optimization profile for dynamic input dimensions and shape tensors.
 ///
 /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html)
-pub struct OptimizationProfile<'a> {
-    inner: InnerOptimizationProfile,
-    phantom: PhantomData<&'a ()>,
-}
+pub struct OptimizationProfile<'a>(InnerOptimizationProfile<'a>);
 
 impl<'a> OptimizationProfile<'a> {
     /// Create [`OptimizationProfile`] from its inner object.
-    pub fn from_inner(inner: InnerOptimizationProfile) -> OptimizationProfile<'a> {
-        Self {
-            inner,
-            phantom: PhantomData,
-        }
+    pub fn from_inner(inner: InnerOptimizationProfile<'a>) -> OptimizationProfile<'a> {
+        Self(inner)
     }
 
     /// Set the minimum dimensions for a dynamic input tensor.
@@ -26,7 +18,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ab723695382d6b03d4a0463b8cbe2b19f)
     #[inline(always)]
     pub fn set_min_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
-        return self.inner.set_min_dimensions(input_name, dims);
+        return self.0.set_min_dimensions(input_name, dims);
     }
 
     /// Set the optimum dimensions for a dynamic input tensor.
@@ -34,7 +26,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ab723695382d6b03d4a0463b8cbe2b19f)
     #[inline(always)]
     pub fn set_opt_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
-        return self.inner.set_opt_dimensions(input_name, dims);
+        return self.0.set_opt_dimensions(input_name, dims);
     }
 
     /// Set the maximum dimensions for a dynamic input tensor.
@@ -42,7 +34,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ab723695382d6b03d4a0463b8cbe2b19f)
     #[inline(always)]
     pub fn set_max_dimensions(&mut self, input_name: &str, dims: &[i32]) -> bool {
-        return self.inner.set_max_dimensions(input_name, dims);
+        return self.0.set_max_dimensions(input_name, dims);
     }
 
     /// Get the minimum dimensions for a dynamic input tensor.
@@ -50,7 +42,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a495725c79864f3e4059055307a8cc59d)
     #[inline(always)]
     pub fn get_min_dimensions(&'a self, input_name: &str) -> Option<Vec<i32>> {
-        return self.inner.get_min_dimensions(input_name);
+        return self.0.get_min_dimensions(input_name);
     }
 
     /// Get the optimum dimensions for a dynamic input tensor.
@@ -58,7 +50,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a495725c79864f3e4059055307a8cc59d)
     #[inline(always)]
     pub fn get_opt_dimensions(&'a self, input_name: &str) -> Option<Vec<i32>> {
-        return self.inner.get_opt_dimensions(input_name);
+        return self.0.get_opt_dimensions(input_name);
     }
 
     /// Get the maximum dimensions for a dynamic input tensor.
@@ -66,7 +58,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a495725c79864f3e4059055307a8cc59d)
     #[inline(always)]
     pub fn get_max_dimensions(&'a self, input_name: &str) -> Option<Vec<i32>> {
-        return self.inner.get_max_dimensions(input_name);
+        return self.0.get_max_dimensions(input_name);
     }
 
     /// Set the minimum values for an input shape tensor.
@@ -74,7 +66,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ad89508bb5e59d46d106cb74d70193485)
     #[inline(always)]
     pub fn set_min_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
-        return self.inner.set_min_shape_values(input_name, values);
+        return self.0.set_min_shape_values(input_name, values);
     }
 
     /// Set the optimum values for an input shape tensor.
@@ -82,7 +74,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ad89508bb5e59d46d106cb74d70193485)
     #[inline(always)]
     pub fn set_opt_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
-        return self.inner.set_opt_shape_values(input_name, values);
+        return self.0.set_opt_shape_values(input_name, values);
     }
 
     /// Set the maximum values for an input shape tensor.
@@ -90,7 +82,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ad89508bb5e59d46d106cb74d70193485)
     #[inline(always)]
     pub fn set_max_shape_values(&mut self, input_name: &str, values: &[i32]) -> bool {
-        return self.inner.set_max_shape_values(input_name, values);
+        return self.0.set_max_shape_values(input_name, values);
     }
 
     /// Get the minimum values for an input shape tensor.
@@ -98,7 +90,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a0654f6beafd1e4004950d5cd45ecab2b)
     #[inline(always)]
     pub fn get_min_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
-        return self.inner.get_min_shape_values(input_name);
+        return self.0.get_min_shape_values(input_name);
     }
 
     /// Get the optimum values for an input shape tensor.
@@ -106,7 +98,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a0654f6beafd1e4004950d5cd45ecab2b)
     #[inline(always)]
     pub fn get_opt_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
-        return self.inner.get_opt_shape_values(input_name);
+        return self.0.get_opt_shape_values(input_name);
     }
 
     /// Get the maximum values for an input shape tensor.
@@ -114,7 +106,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#a0654f6beafd1e4004950d5cd45ecab2b)
     #[inline(always)]
     pub fn get_max_shape_values(&self, input_name: &str) -> Result<Option<Vec<i32>>> {
-        return self.inner.get_max_shape_values(input_name);
+        return self.0.get_max_shape_values(input_name);
     }
 
     /// Set a target for extra GPU memory that may be used by this profile.
@@ -122,7 +114,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ae817a3cfb3f528a7b00173336521a187)
     #[inline(always)]
     pub fn set_extra_memory_target(&mut self, target: f32) -> bool {
-        self.inner.set_extra_memory_target(target)
+        self.0.set_extra_memory_target(target)
     }
 
     /// Get the extra memory target that has been defined for this profile.
@@ -130,7 +122,7 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#aa5339baa4f134993667bc2df94cb0c2e)
     #[inline(always)]
     pub fn get_extra_memory_target(&self) -> f32 {
-        self.inner.get_extra_memory_target()
+        self.0.get_extra_memory_target()
     }
 
     /// Check whether the optimization profile can be passed to an IBuilderConfig object.
@@ -138,10 +130,10 @@ impl<'a> OptimizationProfile<'a> {
     /// [TensorRT documentation](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html#ae817a3cfb3f528a7b00173336521a187)
     #[inline(always)]
     pub fn is_valid(&self) -> bool {
-        self.inner.is_valid()
+        self.0.is_valid()
     }
 
     pub fn inner(&self) -> &InnerOptimizationProfile {
-        &self.inner
+        &self.0
     }
 }


### PR DESCRIPTION
This PR add an implementation for [IOptimizationProfile](https://docs.nvidia.com/deeplearning/tensorrt/api/c_api/classnvinfer1_1_1_i_optimization_profile.html). When building certain engines, setting the input shapes are required for the engine to successfully build.

The main API holds a reference to the inner optimization profile object, as the optimization profile's lifetime is tied to the builder and is destroying when the builder is destroyed. By treating the optimization profile as a reference, this ensures that the optimization profile API is safe to use.

~~This PR is technically a breaking change as the return type of  `Builder::add_optimization_profile` has changed. I don't think this is a big deal, but I figure I would ask before making a potentially breaking change.~~

This PR adds a new function `Builder::create_optimization_profile` to match the TensorRT API. It might be recommeded to remove or deprecate `Builder::add_optimization_profile` and `Builder::with_optimization_profile`.

Example:

```rust
// builder: &mut EngineBuilder,
// network: &mut NetworkDefinition,

let mut builder_config = builder.config().await;
let mut optimization_profile = builder.add_optimization_profile()?;
let input_dimensions = [4, 3, 512, 512];
let inputs = network.inputs();
optimization_profile.set_min_dimensions(&inputs[0].name(), &input_dimensions);
builder_config.add_optimization_profile(optimization_profile)?;

// or
// let builder_config = builder.config().await.with_optimization_profile(op).with_fp16();
```