### PR TITLE
Feat: add additional options

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -29,8 +29,7 @@ dependencies = [
 [[package]]
 name = "async-cuda"
 version = "0.6.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "56bf487caab780f706b84b5714aa01c27996429d0d0e1538617582038dd0526c"
+source = "git+https://github.com/micahcc/async-cuda.git?branch=main#80bf68771b6da5a2e1c97cf6045668348dc9be76"
 dependencies = [
  "cpp",
  "cpp_build",

--- a/Cargo.toml
+++ b/Cargo.toml
@@ -15,6 +15,10 @@ async-cuda = "0.6.1"
 cpp = "0.5"
 tracing = "0.1"
 
+[patch.crates-io]
+# need to upstream cuda get devices
+async-cuda = { git = "https://github.com/micahcc/async-cuda.git", branch = "main"}
+
 [dev-dependencies]
 tempfile = "3.4"
 tokio = { version = "1", default-features = false, features = [

--- a/src/ffi/pre/includes.rs
+++ b/src/ffi/pre/includes.rs
@@ -3,7 +3,6 @@ use cpp::cpp;
 cpp! {{
     #include <cstdint>
     #include <string>
-    #include <cstdio>
 }}
 
 cpp! {{

--- a/src/ffi/pre/includes.rs
+++ b/src/ffi/pre/includes.rs
@@ -3,6 +3,7 @@ use cpp::cpp;
 cpp! {{
     #include <cstdint>
     #include <string>
+    #include <cstdio>
 }}
 
 cpp! {{

--- a/src/ffi/sync/engine.rs
+++ b/src/ffi/sync/engine.rs
@@ -298,7 +298,7 @@ impl ExecutionContext<'static> {
 }
 
 impl<'engine> ExecutionContext<'engine> {
-    pub fn new(engine: &'engine mut Engine) -> Result<Self> {
+    pub fn new(engine: &'engine Engine) -> Result<Self> {
         let internal = unsafe { Self::new_internal(engine) };
         result!(
             internal,

--- a/src/ffi/sync/engine.rs
+++ b/src/ffi/sync/engine.rs
@@ -32,6 +32,7 @@ unsafe impl Send for Engine {}
 /// The TensorRT API is thread-safe with regards to all operations on [`Engine`].
 unsafe impl Sync for Engine {}
 
+#[derive(Copy, Clone, Debug)]
 pub enum DataType {
     /// 32-bit floating point format.
     Float,

--- a/src/ffi/sync/engine.rs
+++ b/src/ffi/sync/engine.rs
@@ -406,12 +406,9 @@ impl<'engine> ExecutionContext<'engine> {
             tensor_name_ptr as "const char*",
             buffer_ptr as "void*"
         ] -> bool as "bool" {
-            const void* prevTensorAddr = ((IExecutionContext*) internal)->getTensorAddress(
-                tensor_name_ptr);
             return ((IExecutionContext*) internal)->setTensorAddress(
                 tensor_name_ptr,
-                0
-                //buffer_ptr
+                buffer_ptr
             );
         });
         if success {

--- a/src/ffi/sync/engine.rs
+++ b/src/ffi/sync/engine.rs
@@ -100,13 +100,15 @@ impl Engine {
             internal as "const void*",
             io_tensor_index as "int"
         ] -> i32 as "DataType" {
-            #if NV_TENSORRT_MAJOR >= 10
+            // Added in TRT 8
+            #if NV_TENSORRT_MAJOR >= 8
             const char* name = ((const ICudaEngine*) internal)->getIOTensorName(io_tensor_index);
             if(name == nullptr) {
-                return DataType::Float;
+                return DataType::kFLOAT;
             }
-            return ((const ICudaEngine*) internal)->getTensorDataType(tensor_name_ptr);
+            return ((const ICudaEngine*) internal)->getTensorDataType(name);
             #else
+            // Removed in TRT 10
             return ((const ICudaEngine*) internal)->getBindingDataType(io_tensor_index);
             #endif
         });

--- a/src/ffi/sync/engine.rs
+++ b/src/ffi/sync/engine.rs
@@ -387,10 +387,8 @@ impl<'engine> ExecutionContext<'engine> {
             internal_engine as "void*"
         ] -> *mut std::ffi::c_void as "void*" {
             void* out = (void*) ((ICudaEngine*) internal_engine)->createExecutionContext();
-            fprintf(stderr, "Execution Ptr: %p\n", out);
             return out;
         });
-        eprintln!("ExecutionContext address: {internal:?}");
         internal
     }
 
@@ -403,19 +401,13 @@ impl<'engine> ExecutionContext<'engine> {
         let tensor_name_cstr = std::ffi::CString::new(tensor_name).unwrap();
         let tensor_name_ptr = tensor_name_cstr.as_ptr();
         let buffer_ptr = buffer_ptr.as_ptr();
-        eprintln!("buffer: {buffer_ptr:?}");
         let success = cpp!(unsafe [
             internal as "void*",
             tensor_name_ptr as "const char*",
             buffer_ptr as "void*"
         ] -> bool as "bool" {
-            fprintf(stderr, "Engine: %p\n", internal);
-            fprintf(stderr, "Getting tensor name: %s\n", tensor_name_ptr);
             const void* prevTensorAddr = ((IExecutionContext*) internal)->getTensorAddress(
                 tensor_name_ptr);
-            fprintf(stderr, "Prev addr: %p", prevTensorAddr);
-
-            fprintf(stderr, "Setting tensor name: %s, buffer ptr: %p, execution: %p\n", tensor_name_ptr, buffer_ptr, internal);
             return ((IExecutionContext*) internal)->setTensorAddress(
                 tensor_name_ptr,
                 0

--- a/src/ffi/sync/engine.rs
+++ b/src/ffi/sync/engine.rs
@@ -69,7 +69,6 @@ pub enum DataType {
 impl Engine {
     #[inline]
     pub(crate) fn wrap(internal: *mut std::ffi::c_void, runtime: Runtime) -> Self {
-        eprintln!("Engine address: {internal:?}");
         Engine { internal, runtime }
     }
 
@@ -211,7 +210,6 @@ impl Engine {
 
 impl Drop for Engine {
     fn drop(&mut self) {
-        eprintln!("Dropping Engine");
         Device::set_or_panic(self.runtime.device());
         let Engine { internal, .. } = *self;
         cpp!(unsafe [
@@ -434,7 +432,6 @@ impl<'engine> ExecutionContext<'engine> {
 
 impl<'engine> Drop for ExecutionContext<'engine> {
     fn drop(&mut self) {
-        eprintln!("Dropping ExecutionContext");
         Device::set_or_panic(self.device);
         let ExecutionContext { internal, .. } = *self;
         cpp!(unsafe [


### PR DESCRIPTION
- In order to bind multiple different types, its necessary to bind multiple things separately from inference.
- Also add a function to get the type